### PR TITLE
 CounteSS now starts automatically

### DIFF
--- a/lib/countess.js
+++ b/lib/countess.js
@@ -24,7 +24,7 @@ export default {
   *********************************************************************/
   activate (state) {
     this.countess = new CounteSS();
-    this.isActive = false;
+    this.isActive = true;
 
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     this.subscriptions = new CompositeDisposable();
@@ -34,7 +34,21 @@ export default {
       'countess:toggle': () => this.toggle()
     }));
 
-    this.countess.editor.getBuffer().onDidStopChanging(this.live.bind(this));
+    setTimeout(this.initBuffer.bind(this));
+  },
+
+
+  /*********************************************************************
+  * Initialze the first buffer, if ready
+  *********************************************************************/
+  initBuffer () {
+    if (this.countess.editor) {
+      this.bufferChange = this.countess.editor.getBuffer().onDidStopChanging(this.live.bind(this));
+      this.editorCHange = atom.workspace.onDidChangeActiveTextEditor(this.editorChange.bind(this));
+      this.live();
+    } else {
+      console.info("NO ACTIVE BUFFER FOUND");
+    }
   },
 
 
@@ -45,6 +59,18 @@ export default {
     this.subscriptions.dispose();
   },
 
+  /*********************************************************************
+  * Call this function when the editor changes.
+  *********************************************************************/
+  editorChange (editor) {
+    if (editor) {
+      this.bufferChange.dispose();
+      this.countess.removeAnnotations();
+      this.countess.editor = editor;
+      this.bufferChange = this.countess.editor.getBuffer().onDidStopChanging(this.live.bind(this));
+      this.live();
+    }
+  },
 
   /*********************************************************************
   * Suppose to return an object that can be retrieved when package is

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "css validator",
     "validator"
   ],
-  "activationCommands": {
-    "atom-workspace": "countess:toggle"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kyle-west/countess.git"


### PR DESCRIPTION
The goals for this PR were:
- [x] Fix issue [#6](#6) and update the buffer analysis to always be the current active buffer.
- [x] Add the feature to start up automatically with Atom, and toggle the markup on or off with `ctrl-alt-o`
- [x] Handle empty buffers to not crash CounteSS